### PR TITLE
Added redirect for one variation

### DIFF
--- a/src/pages/poe/economy/[league]/item-group/index.tsx
+++ b/src/pages/poe/economy/[league]/item-group/index.tsx
@@ -69,6 +69,12 @@ export default function EconomyKeyGroup() {
     }
   );
 
+  if (itemValueTimeseries.length === 1) {
+    router.push(
+      `/poe/economy/${league}/item-group/${itemValueTimeseries[0].itemGroup.hashString}`
+    );
+  }
+
   const cols = [
     ...new Set<string>(
       itemValueTimeseries.flatMap((ivt) =>


### PR DESCRIPTION
Adds a quick check that redirects to the items page, instead of a list of variations if there are no variations.