### PR TITLE
Characters page layout tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 ## PoeStack - Next.js
 
 The frontend app for PoeStack
+
+### Running Locally
+
+Can replace "poestack" with any name you want in the below and can change the first port number to the host port you want to use.
+
+- `$ docker build -f ./Dockerfile -t poestack .`
+
+- `$ docker run -p 3000:3000 -it poestack`

--- a/src/components/character-aggregation-display.tsx
+++ b/src/components/character-aggregation-display.tsx
@@ -3,6 +3,7 @@ import { GenericAggregation } from "../__generated__/resolvers-types";
 import { useEffect } from "react";
 import { FixedSizeList as List } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
+import { GeneralUtils } from "../utils/general-util";
 
 export default function CharacterAggreationDisplay({
   aggregation,
@@ -59,7 +60,7 @@ export default function CharacterAggreationDisplay({
           includedRows.includes(mappedRow[index].key) ? "text-green-400" : ""
         }
       >
-        {mappedRow[index].key}
+        {GeneralUtils.capitalize(mappedRow[index].key)}
       </div>
       <div className={"text-right"}>
         {+(((mappedRow[index]?.value ?? 0) / totalMatches) * 100).toFixed(2)}%

--- a/src/components/styled-input.tsx
+++ b/src/components/styled-input.tsx
@@ -24,7 +24,7 @@ export default function StyledInput({
           type={type}
           id={id}
           value={value ?? ""}
-          className="bg-transparent border border-theme-color-2 focus:border-theme-color-2 rounded-lg m-2"
+          className="bg-transparent border border-theme-color-2 focus:border-theme-color-2 rounded-lg m-2 w-full"
           placeholder={placeholder}
           required
           onChange={(e) => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -43,11 +43,11 @@ export default function App({ Component, pageProps }: AppProps) {
               <div className="flex flex-col w-full h-full min-h-screen overflow-x-auto">
                 <StyledNavBar />
                 <div className="flex grow space-x-2 pt-4">
-                  <div className="lg:basis-1/4"></div>
-                  <div className="grow lg:basis-1/2">
+                  <div className="lg:basis-1/12"></div>
+                  <div className="grow lg:basis-5/6">
                     <Component {...pageProps} />
                   </div>
-                  <div className="lg:basis-1/4"></div>
+                  <div className="lg:basis-1/12"></div>
                 </div>
                 <div className="flex flex-row space-x-3">
                   <div>

--- a/src/pages/poe/characters/index.tsx
+++ b/src/pages/poe/characters/index.tsx
@@ -181,7 +181,7 @@ export default function Characters() {
   return (
     <>
       <div className="flex flex-row space-x-2">
-        <div className="flex flex-col space-y-2 w-1/6">
+        <div className="flex flex-col space-y-2 w-1/6 lg:w-1/5">
           <StyledCard title={"Search"}>
             <StyledInput
               value={localSearchString}

--- a/src/pages/poe/characters/index.tsx
+++ b/src/pages/poe/characters/index.tsx
@@ -16,6 +16,7 @@ import {
   CharacterSnapshotSearch,
   CharacterSnapshotUniqueAggregationKeysResponse,
 } from "../../../__generated__/resolvers-types";
+import { GeneralUtils } from "../../../utils/general-util";
 
 export default function Characters() {
   const router = useRouter();
@@ -277,7 +278,7 @@ export default function Characters() {
                         {snapshot?.name}
                       </Link>
                     </td>
-                    <td>{snapshot.mainSkillKey}</td>
+                    <td>{GeneralUtils.capitalize(snapshot.mainSkillKey)}</td>
                     <td>{snapshot.life}</td>
                     <td>{snapshot.energyShield}</td>
                     <td>{snapshot.characterClass}</td>


### PR DESCRIPTION
Hi, 

Not sure if you want PR's like these or what your strategy is for contributions, but for the Characters page I capitalized the skill names in the main table and the side search bar, made the gutters a bit smaller and the main table bigger, and made the search side bar a little bigger on larger displays. Oh, I also made the search input field not overflow its sidebar.

I was really only looking at the Characters page, so if my changes would adversely impact any other pages, please let me know!

I have experience with Angular, but am new to React and haven't used Tailwind CSS yet, so was neat to look into that a little. I'll have to check out your Discord soon. I hadn't seen your website until I saw your Reddit post today; seems like a cool idea!

Cheers,
Jeff