### PR TITLE
Clean up the characters page

### DIFF
--- a/src/pages/poe/characters/index.tsx
+++ b/src/pages/poe/characters/index.tsx
@@ -1,35 +1,26 @@
+import { useState, useEffect, Dispatch } from "react";
 import { gql, useQuery } from "@apollo/client";
-
+import client from "../../../poe-stack-apollo-client";
+import { usePoeLeagueCtx } from "../../../contexts/league-context";
+import { Maybe } from "graphql/jsutils/Maybe";
 import Link from "next/link";
 import Image from "next/image";
-
-import { useState, useEffect } from "react";
-import { useRouter } from "next/router";
-import StyledCard from "../../../components/styled-card";
-import Datepicker from "tailwind-datepicker-react";
-import {
-  CharacterSnapshotSearchResponse,
-  CharacterSnapshotSearchAggregationsResponse,
-} from "../../../__generated__/graphql";
-import { usePoeLeagueCtx } from "../../../contexts/league-context";
 import CharacterAggregationDisplay from "../../../components/character-aggregation-display";
-import StyledInput from "../../../components/styled-input";
-import {
-  CharacterSnapshotSearch,
-  CharacterSnapshotUniqueAggregationKeysResponse,
-} from "../../../__generated__/graphql";
-import {
-  StyledSkillImageTooltip,
-  StyledTooltip,
-} from "../../../components/styled-tooltip";
-import client from "../../../poe-stack-apollo-client";
+import StyledCard from "../../../components/styled-card";
 import StyledDatepicker from "../../../components/styled-datepicker";
+import StyledInput from "../../../components/styled-input";
+import { StyledTooltip, StyledSkillImageTooltip } from "../../../components/styled-tooltip";
+import { 
+    CharacterSnapshotSearch, 
+    CharacterSnapshotSearchResponse, 
+    CharacterSnapshotSearchAggregationsResponse, 
+    GenericAggregation } from "../../../__generated__/graphql";
+
 
 const generalSearch = gql`
   query Snapshots($search: CharacterSnapshotSearch!) {
     characterSnapshotsSearch(search: $search) {
       snapshots {
-        snapshotId
         characterId
         name
         level
@@ -70,28 +61,17 @@ const generalSearch = gql`
   }
 `;
 
-const uniqueKeysQuery = gql`
-  query CharacterSnapshotsUniqueAggregationKeys($league: String!) {
-    characterSnapshotsUniqueAggregationKeys(league: $league) {
-      characterClassKeys
-      keystoneKeys
-      mainSkillKeys
-      itemKeys
-    }
-  }
-`;
-
+/**
+ * Characters page
+ */
 export default function Characters({
   initialSearchResponse,
   unqiueKeysResponse,
 }) {
-  const router = useRouter();
-
-  const { league, setLeague } = usePoeLeagueCtx();
+  const { league } = usePoeLeagueCtx();
 
   const [search, setSearch] = useState<CharacterSnapshotSearch>({
     league: league,
-    timestampEndInclusive: null,
     includedKeyStoneNames: [],
     excludedKeyStoneNames: [],
     includedCharacterClasses: [],
@@ -104,153 +84,202 @@ export default function Characters({
 
   const [localSearchString, setLocalSearchString] = useState<string>("");
 
-  const [searchResponse, setSearchResponse] = useState<
+  const [characters, setCharacters] = useState<
     CharacterSnapshotSearchResponse | undefined | null
   >(initialSearchResponse?.characterSnapshotsSearch);
-  const [aggregationSearchResponse, setAggregationSearchResponse] = useState<
+
+  const [aggregations, setAggregations] = useState<
     CharacterSnapshotSearchAggregationsResponse | undefined | null
   >(initialSearchResponse?.characterSnapshotsSearchAggregations);
-  const { refetch: reftechGeneralSearch } = useQuery(generalSearch, {
-    skip: true,
-    variables: { search: { ...search, ...{ league: league } } },
-    onCompleted(data) {
-      setSearchResponse({
-        ...searchResponse,
-        ...data.characterSnapshotsSearch,
-      });
-      setAggregationSearchResponse({
-        ...aggregationSearchResponse,
-        ...data.characterSnapshotsSearchAggregations,
-      });
-    },
-  });
+
+  const { refetch: reftechGeneralSearch } = useQuery(
+    generalSearch, 
+    {
+      skip: true,
+      variables: { search: { ...search, ...{ league: league } } },
+      onCompleted(data) {
+        setCharacters({
+          ...characters,
+          ...data.characterSnapshotsSearch,
+        });
+        setAggregations({
+          ...aggregations,
+          ...data.characterSnapshotsSearchAggregations,
+        });
+      },
+    });
 
   useEffect(() => {
     reftechGeneralSearch();
   }, [search, reftechGeneralSearch, league]);
 
-  const updateIncludeExclude = (entry, includedKey, excludedKey) => {
-    if (search[includedKey]?.includes(entry.key)) {
-      setSearch({
-        ...search,
-        ...{
-          [excludedKey]: [...search[excludedKey]!, entry.key],
-          [includedKey]: search[includedKey]!.filter((e) => e !== entry.key),
-        },
-      });
-    } else if (search[excludedKey]?.includes(entry.key)) {
-      setSearch({
-        ...search,
-        ...{
-          [excludedKey]: search[excludedKey]!.filter((e) => e !== entry.key),
-        },
-      });
-    } else {
-      setSearch({
-        ...search,
-        ...{
-          [includedKey]: [...search[includedKey]!, entry.key],
-        },
-      });
-    }
-  };
-
-  if (!searchResponse) {
+  if (!characters) {
     return <>Loading...</>;
   }
+
+  /*
+   * Define callbacks as functions instead of consts
+   * to skip revaluation on every component view update.
+   */
+
+  function updateIncludeExclude (
+    search: CharacterSnapshotSearch, 
+    setSearch:Dispatch<any>, 
+    entry: {key: string, value: any}, 
+    includedKey: string, 
+    excludedKey: string): void {
+  
+      if (search[includedKey]?.includes(entry.key)) {
+        setSearch({
+          ...search,
+          ...{
+            [excludedKey]: [...search[excludedKey]!, entry.key],
+            [includedKey]: search[includedKey]!.filter((e: string) => e !== entry.key),
+          },
+        });
+      } else if (search[excludedKey]?.includes(entry.key)) {
+        setSearch({
+          ...search,
+          ...{
+            [excludedKey]: search[excludedKey]!.filter((e: string) => e !== entry.key),
+          },
+        });
+      } else {
+        setSearch({
+          ...search,
+          ...{
+            [includedKey]: [...search[includedKey]!, entry.key],
+          },
+        });
+      }
+  }
+
+  function onSkillChange(mainSkill: {key: string, value: any}) {
+    updateIncludeExclude( search, setSearch,
+      mainSkill,
+      "includedMainSkills",
+      "excludedMainSkills"
+    )
+  }
+
+  function onClassChange(characterClass: {key: string, value: any}) {
+    updateIncludeExclude( search, setSearch,
+      characterClass,
+      "includedCharacterClasses",
+      "excludedCharacterClasses"
+    );
+  }
+
+  function onItemChange(item: {key: string, value: any}) {
+    updateIncludeExclude( search, setSearch,
+      item,
+      "includedItemKeys",
+      "excludedItemKeys"
+    );
+  }
+
+  function onKeystoneChange(keyStone: {key: string, value: any}) {
+    updateIncludeExclude( search, setSearch,
+      keyStone,
+      "includedKeyStoneNames",
+      "excludedKeyStoneNames"
+    );
+  }
+
+  function onSearchValueChange(e) { setLocalSearchString(e); }
+
+  function onDateChange(d) {
+    setSearch({
+      ...search,
+      ...{ timestampEndInclusive: d.toISOString() },
+    });
+  }
+
+  /*
+   * These models are used to create the individual
+   * aggregation panels
+   */
+
+  const aggregatorPanels: Array<StyledAggregatorPanelModel> = [{       
+    title:"Skills",
+    aggregation:aggregations?.mainSkillAggreagtion,
+    onSelectionChanged: onSkillChange,
+    includedRows:search.includedMainSkills!,
+    excludedRows:search.excludedMainSkills!,
+    keys: unqiueKeysResponse?.mainSkillKeys,
+    matches: aggregations?.totalMatches,
+    searchString: localSearchString
+  },
+  {
+    title: "Class",
+    aggregation: aggregations?.characterClassAggregation,
+    onSelectionChanged: onClassChange,
+    includedRows: search.includedCharacterClasses!,
+    excludedRows: search.excludedCharacterClasses!,
+    keys: unqiueKeysResponse?.characterClassKeys,
+    matches: aggregations?.totalMatches,
+    searchString: localSearchString
+  },
+  {
+    title: "Items",
+    aggregation: aggregations?.itemKeyAggreagtion,
+    onSelectionChanged: onItemChange,
+    includedRows: search.includedItemKeys!,
+    excludedRows: search.excludedItemKeys!,
+    keys: unqiueKeysResponse?.itemKeys,
+    matches: aggregations?.totalMatches,
+    searchString: localSearchString
+  },
+  {
+    title: "Keystones",
+    aggregation: aggregations?.keystoneAggregation,
+    onSelectionChanged: onKeystoneChange,
+    includedRows: search.includedKeyStoneNames!,
+    excludedRows: search.excludedKeyStoneNames!,
+    keys: unqiueKeysResponse?.keystoneKeys,
+    matches: aggregations?.totalMatches,
+    searchString: localSearchString
+  }];
 
   return (
     <>
       <div className="flex flex-row space-x-2 ">
         <div className="flex flex-col space-y-2 w-1/6 lg:w-1/5">
-          <StyledCard title={"Search"}>
-            <StyledInput
-              value={localSearchString}
-              onChange={(e) => {
-                setLocalSearchString(e);
-              }}
-              placeholder="Search Filters..."
-            />
-            <StyledDatepicker
-              onSelectionChange={(d) => {
-                setSearch({
-                  ...search,
-                  ...{ timestampEndInclusive: d.toISOString() },
-                });
-              }}
-            />
-          </StyledCard>
-          <StyledCard title="Skills" className="h-[400px]">
-            <CharacterAggregationDisplay
-              aggregation={aggregationSearchResponse?.mainSkillAggreagtion}
-              onSelectionChanged={(mainSkill) => {
-                updateIncludeExclude(
-                  mainSkill,
-                  "includedMainSkills",
-                  "excludedMainSkills"
-                );
-              }}
-              includedRows={search.includedMainSkills!}
-              excludedRows={search.excludedMainSkills!}
-              allKeys={unqiueKeysResponse?.mainSkillKeys ?? []}
-              totalMatches={aggregationSearchResponse?.totalMatches ?? 0}
-              localSearchString={localSearchString}
-            />
-          </StyledCard>
-          <StyledCard title="Class" className="h-[400px]">
-            <CharacterAggregationDisplay
-              aggregation={aggregationSearchResponse?.characterClassAggregation}
-              onSelectionChanged={(characterClass) => {
-                updateIncludeExclude(
-                  characterClass,
-                  "includedCharacterClasses",
-                  "excludedCharacterClasses"
-                );
-              }}
-              includedRows={search.includedCharacterClasses!}
-              excludedRows={search.excludedCharacterClasses!}
-              allKeys={unqiueKeysResponse?.characterClassKeys ?? []}
-              totalMatches={aggregationSearchResponse?.totalMatches ?? 0}
-              localSearchString={localSearchString}
-            />
-          </StyledCard>
-          <StyledCard title="Items" className="h-[400px]">
-            <CharacterAggregationDisplay
-              aggregation={aggregationSearchResponse?.itemKeyAggreagtion}
-              onSelectionChanged={(item) => {
-                updateIncludeExclude(
-                  item,
-                  "includedItemKeys",
-                  "excludedItemKeys"
-                );
-              }}
-              includedRows={search.includedItemKeys!}
-              excludedRows={search.excludedItemKeys!}
-              allKeys={unqiueKeysResponse?.itemKeys ?? []}
-              totalMatches={aggregationSearchResponse?.totalMatches ?? 0}
-              localSearchString={localSearchString}
-            />
-          </StyledCard>
-          <StyledCard title="Keystones" className="h-[400px]">
-            <CharacterAggregationDisplay
-              aggregation={aggregationSearchResponse?.keystoneAggregation}
-              onSelectionChanged={(keyStone) => {
-                updateIncludeExclude(
-                  keyStone,
-                  "includedKeyStoneNames",
-                  "excludedKeyStoneNames"
-                );
-              }}
-              includedRows={search.includedKeyStoneNames!}
-              excludedRows={search.excludedKeyStoneNames!}
-              allKeys={unqiueKeysResponse?.keystoneKeys ?? []}
-              totalMatches={aggregationSearchResponse?.totalMatches ?? 0}
-              localSearchString={localSearchString}
-            />
-          </StyledCard>
+          
+          <StyledMultiSearch 
+            value={localSearchString} 
+            onValueChange={onSearchValueChange}
+            onDateChange={onDateChange}/>
+
+          {aggregatorPanels.map(props=><StyledAggregatorPanel key={props.title} {...props}/>)}
+          
         </div>
+
+        <StyledCharactersSummaryTable characters={characters}/>
+
+      </div>
+    </>
+  );
+}
+
+/*
+ * Sub components for the characters page
+ */
+
+/**
+ * Props for {@link StyledCharactersSummaryTable}
+ */
+type StyledCharactersSummaryTableProps = {
+    characters: CharacterSnapshotSearchResponse
+};
+
+/**
+ * Table of a brief summary of characters on the {@link Characters} page. 
+ */
+function StyledCharactersSummaryTable({characters}: StyledCharactersSummaryTableProps) {
+    return (
         <StyledCard title="Characters" className="flex-1">
-          <table>
+            <table>
             {/* Setup for adding click sort like PoeNinja */}
             <thead className="text-left">
               <tr>
@@ -261,82 +290,170 @@ export default function Characters({
                 <th className="pl-2">Es</th>
               </tr>
             </thead>
-            <tbody className="">
-              {searchResponse.snapshots.map((snapshot) => (
-                <>
-                  <tr className="hover:bg-skin-primary border-y-2 border-slate-700/50">
-                    <td>
-                      <Link
-                        href={`/poe/character/${snapshot.characterId}?snapshotId=${snapshot.snapshotId}`}
-                        className="hover:text-skin-accent hover:underline pl-3"
-                      >
-                        {snapshot?.name}
-                      </Link>
-                    </td>
-                    <td>
-                      <ul className="flex flex-row space-x-3 justify-left">
-                        <li className="text-center list-none w-1/5">
-                          {snapshot.level}
-                        </li>
-                        <li className="list-none">
-                          <StyledTooltip
-                            texts={[`${snapshot.characterClass}`]}
-                            placement="right"
-                            className="bg-slate-800"
-                          >
-                            <Image
-                              src={`/assets/poe/classes/${snapshot.characterClass}.png`}
-                              alt={snapshot.characterClass}
-                              width={39}
-                              height={30}
-                            />
-                          </StyledTooltip>
-                        </li>
-                      </ul>
-                    </td>
+                <tbody className="">
+                    {characters.snapshots.map((snapshot) => (
+                      <tr className="hover:bg-skin-primary border-y-2 border-slate-700/50" key={snapshot.characterId}>
+                        <td>
+                            <Link
+                            href={`/poe/character/${snapshot.characterId}?snapshotId=${snapshot.snapshotId}`}
+                            className="hover:text-skin-accent hover:underline pl-3"
+                            >
+                            {snapshot?.name}
+                            </Link>
+                        </td>
+                        <td>
+                            <ul className="flex flex-row space-x-3 justify-left">
+                            <li className="text-center list-none w-1/5">
+                                {snapshot.level}
+                            </li>
+                            <li className="list-none">
+                                <StyledTooltip
+                                texts={[`${snapshot.characterClass}`]}
+                                placement="right"
+                                className="bg-slate-800"
+                                >
+                                <Image
+                                    src={`/assets/poe/classes/${snapshot.characterClass}.png`}
+                                    alt={snapshot.characterClass}
+                                    width={39}
+                                    height={30}
+                                />
+                                </StyledTooltip>
+                            </li>
+                            </ul>
+                        </td>
 
-                    <td>
-                      {snapshot.mainSkillKey ? (
-                        <li className="list-none">
-                          <StyledSkillImageTooltip
-                            texts={[`${snapshot.mainSkillKey}`]}
-                            placement="left"
-                            title="Skills"
-                            imageString={snapshot.mainSkillKey}
-                            className="bg-slate-800"
-                          >
-                            <Image
-                              src={`/assets/poe/skill_icons/${snapshot.mainSkillKey}.png`}
-                              alt=""
-                              width={39}
-                              height={30}
-                            />
-                          </StyledSkillImageTooltip>
-                        </li>
-                      ) : null}
-                    </td>
+                        <td>
+                            {snapshot.mainSkillKey ? (
+                            <li className="list-none">
+                                <StyledSkillImageTooltip
+                                texts={[`${snapshot.mainSkillKey}`]}
+                                placement="left"
+                                title="Skills"
+                                imageString={snapshot.mainSkillKey}
+                                className="bg-slate-800"
+                                >
+                                <Image
+                                    src={`/assets/poe/skill_icons/${snapshot.mainSkillKey}.png`}
+                                    alt=""
+                                    width={39}
+                                    height={30}
+                                />
+                                </StyledSkillImageTooltip>
+                            </li>
+                            ) : null}
+                        </td>
 
-                    <td className="font-semibold text-red-600">
-                      {snapshot.life}
-                    </td>
-                    <td className="font-semibold text-teal-300">
-                      {snapshot.energyShield}
-                    </td>
-                  </tr>
-                </>
-              ))}
-            </tbody>
-          </table>
-        </StyledCard>
-      </div>
-    </>
-  );
+                        <td className="font-semibold text-red-600">
+                            {snapshot.life}
+                        </td>
+                        <td className="font-semibold text-teal-300">
+                            {snapshot.energyShield}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+            </table>
+        </StyledCard>);
 }
+
+/**
+ * Props for {@link StyledMultiSearch}
+ */
+type StyledMultiSearchProps = { 
+    value: string, 
+    onValueChange: (e: any)=>void, 
+    onDateChange: (e: any)=>void 
+};
+
+/**
+ * Styled search input for filtering aggregates on the {@link Characters} page
+ */
+function StyledMultiSearch({ 
+    value, 
+    onValueChange, 
+    onDateChange }: StyledMultiSearchProps) {
+    return (
+        <StyledCard title={"Search"}>
+            <StyledInput
+              value={value}
+              onChange={onValueChange}
+              placeholder="Search Filters..."
+            />
+            <StyledDatepicker
+              onSelectionChange={onDateChange}
+            />
+        </StyledCard>);
+}
+
+
+type StyledAggregatorPanelProps = {
+    title: string;
+    aggregation: GenericAggregation | undefined | null;
+    onSelectionChanged: (e:{key: string, value: any})=>void;
+    includedRows?: any[];
+    excludedRows?: any[];
+    keys: string[];
+    matches?: Maybe<number>;
+    searchString: string;
+};
+
+/**
+ * A model of the {@link StyledAggregatorPanel} props to instantiate
+ * with.
+ */
+export type StyledAggregatorPanelModel = StyledAggregatorPanelProps;
+
+/**
+ * Panel for  showing aggregate usage of 
+ * passed fields on the {@link Characters} page. 
+ */
+function StyledAggregatorPanel({
+    title,
+    aggregation,
+    onSelectionChanged,
+    includedRows,
+    excludedRows,
+    keys,
+    matches,
+    searchString }: StyledAggregatorPanelProps) {
+
+        keys = keys? keys:[];
+        matches = matches? matches:0;
+        
+        return (
+            <StyledCard title={title} className="h-[400px]">
+                <CharacterAggregationDisplay
+                    aggregation={aggregation}
+                    onSelectionChanged={onSelectionChanged}
+                    includedRows={includedRows}
+                    excludedRows={excludedRows}
+                    allKeys={keys}
+                    totalMatches={matches}
+                    localSearchString={searchString}/>
+            </StyledCard>
+        )
+}
+
+/*
+ * For ssr 
+ */
+
+const uniqueKeysQuery = gql`
+  query CharacterSnapshotsUniqueAggregationKeys($league: String!) {
+    characterSnapshotsUniqueAggregationKeys(league: $league) {
+      characterClassKeys
+      keystoneKeys
+      mainSkillKeys
+      itemKeys
+    }
+  }
+`;
 
 export async function getServerSideProps({ req, res, query }) {
   res.setHeader(
     "Cache-Control",
-    "public, s-maxage=10, stale-while-revalidate=59"
+    "public, s-maxage=600, stale-while-revalidate=1200"
   );
 
   const resp = {
@@ -350,7 +467,6 @@ export async function getServerSideProps({ req, res, query }) {
     variables: {
       search: {
         league: league ?? "Sanctum",
-        timestampEndInclusive: null,
         includedKeyStoneNames: [],
         excludedKeyStoneNames: [],
         includedCharacterClasses: [],


### PR DESCRIPTION
Here is a cleaned up version of the characters page.  The lines increased by quite a bit but you can see how the page itself is reduced to only:

`    
     <>
      <div className="flex flex-row space-x-2 ">
        <div className="flex flex-col space-y-2 w-1/6 lg:w-1/5">
          
          <StyledMultiSearch 
            value={localSearchString} 
            onValueChange={onSearchValueChange}
            onDateChange={onDateChange}/>

          {aggregatorPanels.map(props=><StyledAggregatorPanel key={props.title} {...props}/>)}
          
        </div>

        <StyledCharactersSummaryTable characters={characters}/>

      </div>
    </>`

The rest of the page is split into multiple sub components making them individually easier to work with.

This shows why I think splitting these up into multiple files is the best way to do it.  But even if you want to keep them all in the same file at least this way you can just point someone to the `StyledCharactersSummaryTable` component and they can focus their work there without having to navigate everything else that makes up the characters page.

In my experience it is much easier to get contributors to a project if they can narrow their focus to only the piece they need to change.

What do you think?

Also, it looks like using `yarn install --frozen-lockfile` worked.  I'm not seeing that as changed on this pull request.  So at least progress has been made somewhere :P