### PR TITLE
Add the sorting structure for the characters table

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,14 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": "src",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@contexts/*": ["contexts/*"],
+      "@utils/*": ["utils/*"],
+      "@generated/*": ["__generated__/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/pages/_document.js"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
I've added in the necessary structure to support sorting the columns on the characters page.  I looked through some of the apollo stuff but couldn't figure out how to actually implement the sorting behavior on the `characterSnapshotsSearch` query.

I noticed in the generated data that some of the stuff, like `ItemGroupSearchInput`, has a `sortDirection` defined key.  It's type float which I don't understand but at least something exists there.  But I don't see a similar sort key for `characterSnapshotsSearch`.

Am I just missing something here?

Either way, the structure is in place so that the query could be updated somehow [right at this line](https://github.com/tme321/poestack-next/blob/7c5df558abd20020ccd12acb5aa41defc85fe3a2/src/pages/poe/characters/index.tsx#L143).  Everything else is already in place and working.